### PR TITLE
Added support for host call parameters to be more descriptive types

### DIFF
--- a/dergwasm_mod/Benchmarks/Program.cs
+++ b/dergwasm_mod/Benchmarks/Program.cs
@@ -694,11 +694,11 @@ namespace DergwasmTests
                 {
                     throw new Exception("component__get_member failed");
                 }
-                if (env.value__get<int>(frame, HeapGet(outRefIdPtr), outPtr.Addr) != 0)
+                if (env.value__get(frame, new WRefId<IValue<int>>(HeapGet(outRefIdPtr)), outPtr) != 0)
                 {
                     throw new Exception("value__get failed");
                 }
-                sum += HeapGet<int>(outPtr);
+                sum += HeapGet(outPtr);
             }
             return sum;
         }
@@ -709,11 +709,11 @@ namespace DergwasmTests
             emscriptenEnv.ResetMalloc();
             int sum = 0;
             Ptr<int> outPtr = new Ptr<int>(4);
-            ulong refId = (ulong)testComponent.IntField.ReferenceID;
+            var refId = testComponent.IntField.GetWasmRef<IValue<int>>();;
 
             for (int i = 0; i < N; i++)
             {
-                if (env.value__get<int>(frame, refId, outPtr.Addr) != 0)
+                if (env.value__get(frame, refId, outPtr) != 0)
                 {
                     throw new Exception("value__get failed");
                 }

--- a/dergwasm_mod/Benchmarks/Program.cs
+++ b/dergwasm_mod/Benchmarks/Program.cs
@@ -694,7 +694,7 @@ namespace DergwasmTests
                 {
                     throw new Exception("component__get_member failed");
                 }
-                if (env.value__get(frame, new WRefId<IValue<int>>(HeapGet(outRefIdPtr)), outPtr) != 0)
+                if (env.value__get(frame, new WasmRefID<IValue<int>>(HeapGet(outRefIdPtr)), outPtr) != 0)
                 {
                     throw new Exception("value__get failed");
                 }

--- a/dergwasm_mod/Dergwasm/Frame.cs
+++ b/dergwasm_mod/Dergwasm/Frame.cs
@@ -95,11 +95,9 @@ namespace Derg
 
         public Value Pop() => value_stack.Pop();
 
-        // This is highly expensive because it does boxing and unboxing. It takes about
-        // 4.5x the time to get a value this way. If you already know the type of the
-        // value you're popping, then extract it yourself.
-        public T Pop<T>()
-            where T : unmanaged => Pop().As<T>();
+        public T Pop<T>() => Pop().As<T>();
+
+        public void Push<T>(in T value) => value_stack.Push(Value.From(value));
 
         public void Push(Value val) => value_stack.Push(val);
 
@@ -116,45 +114,6 @@ namespace Derg
         public void Push(float val) => Push(new Value { f32 = val });
 
         public void Push(double val) => Push(new Value { f64 = val });
-
-        // This is about 1.7x the time of a direct push. If you already know the type of the
-        // value you're pushing, then create the value directly and push it.
-        public void Push<R>(R ret)
-        {
-            switch (ret)
-            {
-                case int r:
-                    Push(new Value { s32 = r });
-                    break;
-
-                case uint r:
-                    Push(new Value { u32 = r });
-                    break;
-
-                case long r:
-                    Push(new Value { s64 = r });
-                    break;
-
-                case ulong r:
-                    Push(new Value { u64 = r });
-                    break;
-
-                case float r:
-                    Push(new Value { f32 = r });
-                    break;
-
-                case double r:
-                    Push(new Value { f64 = r });
-                    break;
-
-                case bool r:
-                    Push(r);
-                    break;
-
-                default:
-                    throw new Trap($"Invalid push type {ret.GetType()}");
-            }
-        }
 
         public int StackLevel() => value_stack.Count;
 

--- a/dergwasm_mod/Dergwasm/HostProxy.cs
+++ b/dergwasm_mod/Dergwasm/HostProxy.cs
@@ -29,7 +29,6 @@ namespace Derg
     }
 
     public class HostProxy<T1> : HostProxy
-        where T1 : unmanaged
     {
         Action<Frame, T1> func;
 
@@ -47,8 +46,6 @@ namespace Derg
     }
 
     public class HostProxy<T1, T2> : HostProxy
-        where T1 : unmanaged
-        where T2 : unmanaged
     {
         Action<Frame, T1, T2> func;
 
@@ -66,9 +63,6 @@ namespace Derg
     }
 
     public class HostProxy<T1, T2, T3> : HostProxy
-        where T1 : unmanaged
-        where T2 : unmanaged
-        where T3 : unmanaged
     {
         Action<Frame, T1, T2, T3> func;
 
@@ -91,10 +85,6 @@ namespace Derg
     }
 
     public class HostProxy<T1, T2, T3, T4> : HostProxy
-        where T1 : unmanaged
-        where T2 : unmanaged
-        where T3 : unmanaged
-        where T4 : unmanaged
     {
         Action<Frame, T1, T2, T3, T4> func;
 
@@ -118,11 +108,6 @@ namespace Derg
     }
 
     public class HostProxy<T1, T2, T3, T4, T5> : HostProxy
-        where T1 : unmanaged
-        where T2 : unmanaged
-        where T3 : unmanaged
-        where T4 : unmanaged
-        where T5 : unmanaged
     {
         Action<Frame, T1, T2, T3, T4, T5> func;
 
@@ -147,12 +132,6 @@ namespace Derg
     }
 
     public class HostProxy<T1, T2, T3, T4, T5, T6> : HostProxy
-        where T1 : unmanaged
-        where T2 : unmanaged
-        where T3 : unmanaged
-        where T4 : unmanaged
-        where T5 : unmanaged
-        where T6 : unmanaged
     {
         Action<Frame, T1, T2, T3, T4, T5, T6> func;
 
@@ -196,8 +175,6 @@ namespace Derg
     }
 
     public class ReturningHostProxy<T1, R> : HostProxy
-        where T1 : unmanaged
-        where R : unmanaged
     {
         Func<Frame, T1, R> func;
 
@@ -217,9 +194,6 @@ namespace Derg
     }
 
     public class ReturningHostProxy<T1, T2, R> : HostProxy
-        where T1 : unmanaged
-        where T2 : unmanaged
-        where R : unmanaged
     {
         Func<Frame, T1, T2, R> func;
 
@@ -239,10 +213,6 @@ namespace Derg
     }
 
     public class ReturningHostProxy<T1, T2, T3, R> : HostProxy
-        where T1 : unmanaged
-        where T2 : unmanaged
-        where T3 : unmanaged
-        where R : unmanaged
     {
         Func<Frame, T1, T2, T3, R> func;
 
@@ -269,11 +239,6 @@ namespace Derg
     }
 
     public class ReturningHostProxy<T1, T2, T3, T4, R> : HostProxy
-        where T1 : unmanaged
-        where T2 : unmanaged
-        where T3 : unmanaged
-        where T4 : unmanaged
-        where R : unmanaged
     {
         Func<Frame, T1, T2, T3, T4, R> func;
 
@@ -301,12 +266,6 @@ namespace Derg
     }
 
     public class ReturningHostProxy<T1, T2, T3, T4, T5, R> : HostProxy
-        where T1 : unmanaged
-        where T2 : unmanaged
-        where T3 : unmanaged
-        where T4 : unmanaged
-        where T5 : unmanaged
-        where R : unmanaged
     {
         Func<Frame, T1, T2, T3, T4, T5, R> func;
 
@@ -335,13 +294,6 @@ namespace Derg
     }
 
     public class ReturningHostProxy<T1, T2, T3, T4, T5, T6, R> : HostProxy
-        where T1 : unmanaged
-        where T2 : unmanaged
-        where T3 : unmanaged
-        where T4 : unmanaged
-        where T5 : unmanaged
-        where T6 : unmanaged
-        where R : unmanaged
     {
         Func<Frame, T1, T2, T3, T4, T5, T6, R> func;
 

--- a/dergwasm_mod/Dergwasm/Machine.cs
+++ b/dergwasm_mod/Dergwasm/Machine.cs
@@ -292,7 +292,6 @@ namespace Derg
         }
 
         public void RegisterVoidHostFunc<T1>(string moduleName, string name, Action<Frame, T1> func)
-            where T1 : unmanaged
         {
             RegisterHostFunc(
                 moduleName,
@@ -307,8 +306,6 @@ namespace Derg
             string name,
             Action<Frame, T1, T2> func
         )
-            where T1 : unmanaged
-            where T2 : unmanaged
         {
             RegisterHostFunc(
                 moduleName,
@@ -326,9 +323,6 @@ namespace Derg
             string name,
             Action<Frame, T1, T2, T3> func
         )
-            where T1 : unmanaged
-            where T2 : unmanaged
-            where T3 : unmanaged
         {
             RegisterHostFunc(
                 moduleName,
@@ -351,10 +345,6 @@ namespace Derg
             string name,
             Action<Frame, T1, T2, T3, T4> func
         )
-            where T1 : unmanaged
-            where T2 : unmanaged
-            where T3 : unmanaged
-            where T4 : unmanaged
         {
             RegisterHostFunc(
                 moduleName,
@@ -378,11 +368,6 @@ namespace Derg
             string name,
             Action<Frame, T1, T2, T3, T4, T5> func
         )
-            where T1 : unmanaged
-            where T2 : unmanaged
-            where T3 : unmanaged
-            where T4 : unmanaged
-            where T5 : unmanaged
         {
             RegisterHostFunc(
                 moduleName,
@@ -422,8 +407,6 @@ namespace Derg
             string name,
             Func<Frame, T1, R> func
         )
-            where T1 : unmanaged
-            where R : unmanaged
         {
             RegisterHostFunc(
                 moduleName,
@@ -441,9 +424,6 @@ namespace Derg
             string name,
             Func<Frame, T1, T2, R> func
         )
-            where T1 : unmanaged
-            where T2 : unmanaged
-            where R : unmanaged
         {
             RegisterHostFunc(
                 moduleName,
@@ -461,10 +441,6 @@ namespace Derg
             string name,
             Func<Frame, T1, T2, T3, R> func
         )
-            where T1 : unmanaged
-            where T2 : unmanaged
-            where T3 : unmanaged
-            where R : unmanaged
         {
             RegisterHostFunc(
                 moduleName,
@@ -487,11 +463,6 @@ namespace Derg
             string name,
             Func<Frame, T1, T2, T3, T4, R> func
         )
-            where T1 : unmanaged
-            where T2 : unmanaged
-            where T3 : unmanaged
-            where T4 : unmanaged
-            where R : unmanaged
         {
             RegisterHostFunc(
                 moduleName,
@@ -515,12 +486,6 @@ namespace Derg
             string name,
             Func<Frame, T1, T2, T3, T4, T5, R> func
         )
-            where T1 : unmanaged
-            where T2 : unmanaged
-            where T3 : unmanaged
-            where T4 : unmanaged
-            where T5 : unmanaged
-            where R : unmanaged
         {
             RegisterHostFunc(
                 moduleName,

--- a/dergwasm_mod/Dergwasm/ResoniteEnv.cs
+++ b/dergwasm_mod/Dergwasm/ResoniteEnv.cs
@@ -186,7 +186,7 @@ namespace Derg
             );
 
             machine.RegisterReturningHostFunc<ulong>("env", "slot__root_slot", slot__root_slot);
-            machine.RegisterReturningHostFunc<WRefId<Slot>, WRefId<Slot>>(
+            machine.RegisterReturningHostFunc<WasmRefID<Slot>, WasmRefID<Slot>>(
                 "env",
                 "slot__get_parent",
                 slot__get_parent
@@ -236,17 +236,17 @@ namespace Derg
 
             void RegisterValueGetSet<T>(
                 string name,
-                Func<Frame, WRefId<IValue<T>>, Ptr<T>, ResoniteError> valueGet,
-                Func<Frame, WRefId<IValue<T>>, Ptr<T>, ResoniteError> valueSet
+                Func<Frame, WasmRefID<IValue<T>>, Ptr<T>, ResoniteError> valueGet,
+                Func<Frame, WasmRefID<IValue<T>>, Ptr<T>, ResoniteError> valueSet
             )
                 where T : unmanaged
             {
-                machine.RegisterReturningHostFunc<WRefId<IValue<T>>, Ptr<T>, ResoniteError>(
+                machine.RegisterReturningHostFunc<WasmRefID<IValue<T>>, Ptr<T>, ResoniteError>(
                     "env",
                     $"value__get_{name}",
                     value__get<T>
                 );
-                machine.RegisterReturningHostFunc<WRefId<IValue<T>>, Ptr<T>, ResoniteError>(
+                machine.RegisterReturningHostFunc<WasmRefID<IValue<T>>, Ptr<T>, ResoniteError>(
                     "env",
                     $"value__set_{name}",
                     value__set<T>
@@ -274,7 +274,7 @@ namespace Derg
             return (ulong)slot.ReferenceID;
         }
 
-        public WRefId<Slot> slot__get_parent(Frame frame, WRefId<Slot> slot)
+        public WasmRefID<Slot> slot__get_parent(Frame frame, WasmRefID<Slot> slot)
         {
             return slot.Get(worldServices)?.Parent.GetWasmRef() ?? default;
         }
@@ -418,7 +418,7 @@ namespace Derg
             return 0;
         }
 
-        public ResoniteError value__get<T>(Frame frame, WRefId<IValue<T>> refId, Ptr<T> outPtr)
+        public ResoniteError value__get<T>(Frame frame, WasmRefID<IValue<T>> refId, Ptr<T> outPtr)
             where T : unmanaged
         {
             if (outPtr.IsNull)
@@ -434,7 +434,7 @@ namespace Derg
             return ResoniteError.Success;
         }
 
-        public ResoniteError value__set<T>(Frame frame, WRefId<IValue<T>> refId, Ptr<T> inPtr)
+        public ResoniteError value__set<T>(Frame frame, WasmRefID<IValue<T>> refId, Ptr<T> inPtr)
             where T : unmanaged
         {
             if (inPtr.IsNull)

--- a/dergwasm_mod/Dergwasm/Values.cs
+++ b/dergwasm_mod/Dergwasm/Values.cs
@@ -77,7 +77,6 @@ namespace Derg
             Add(v => (ResoniteError)v.s32, v => new Value { s32 = (int)v });
             Add(v => new Ptr(v.s32), v => new Value { s32 = v.Addr });
             Add(v => new RefID(v.u64), v => new Value { u64 = (ulong)v });
-            Add(v => new WRefId(v.u64), v => new Value { u64 = v.Id });
         }
 
         private static void Add<T>(Func<Value, T> getter, Func<T, Value> setter)
@@ -96,7 +95,7 @@ namespace Derg
                     var method = genericMethod.MakeGenericMethod(typeof(T).GenericTypeArguments);
                     return method.CreateDelegate<Func<Value, T>>();
                 }
-                if (typeof(T).GetGenericTypeDefinition() == typeof(WRefId<>))
+                if (typeof(T).GetGenericTypeDefinition() == typeof(WasmRefID<>))
                 {
                     var genericMethod = typeof(ValueAccessor).GetMethod(nameof(WRefIdGetter));
                     var method = genericMethod.MakeGenericMethod(typeof(T).GenericTypeArguments);
@@ -111,9 +110,9 @@ namespace Derg
             return v => new Ptr<T>(v.s32);
         }
 
-        private static Func<Value, WRefId<T>> WRefIdGetter<T>() where T : class, IWorldElement
+        private static Func<Value, WasmRefID<T>> WRefIdGetter<T>() where T : class, IWorldElement
         {
-            return v => new WRefId<T>(v.u64);
+            return v => new WasmRefID<T>(v.u64);
         }
 
         private static Func<T, Value> CreateSetter<T>()
@@ -126,7 +125,7 @@ namespace Derg
                     var method = genericMethod.MakeGenericMethod(typeof(T).GenericTypeArguments);
                     return method.CreateDelegate<Func<T, Value>>();
                 }
-                if (typeof(T).GetGenericTypeDefinition() == typeof(WRefId<>))
+                if (typeof(T).GetGenericTypeDefinition() == typeof(WasmRefID<>))
                 {
                     var genericMethod = typeof(ValueAccessor).GetMethod(nameof(WRefIdGetter));
                     var method = genericMethod.MakeGenericMethod(typeof(T).GenericTypeArguments);
@@ -141,7 +140,7 @@ namespace Derg
             return v => new Value { s32 = v.Addr };
         }
 
-        private static Func<WRefId<T>, Value> WRefIdSetter<T>() where T : class, IWorldElement
+        private static Func<WasmRefID<T>, Value> WRefIdSetter<T>() where T : class, IWorldElement
         {
             return v => new Value { u64 = v.Id };
         }

--- a/dergwasm_mod/Dergwasm/Wasm/Ptr.cs
+++ b/dergwasm_mod/Dergwasm/Wasm/Ptr.cs
@@ -32,7 +32,7 @@ namespace Derg.Wasm
     {
         public readonly int Addr;
 
-        public bool Valid => Addr != 0;
+        public bool IsNull => Addr == 0;
 
         public static Ptr<T> Null => new Ptr<T>(0);
 

--- a/dergwasm_mod/Dergwasm/Wasm/RefId.cs
+++ b/dergwasm_mod/Dergwasm/Wasm/RefId.cs
@@ -5,32 +5,11 @@ using FrooxEngine;
 namespace Derg.Wasm
 {
     [StructLayout(LayoutKind.Sequential)]
-    public readonly struct WRefId
+    public readonly struct WasmRefID<T> where T : class, IWorldElement
     {
         public readonly ulong Id;
 
-        public WRefId(RefID id)
-        {
-            Id = (ulong)id;
-        }
-
-        public WRefId<T> Reinterpret<T>() where T : class, IWorldElement
-        {
-            return new WRefId<T>(Id);
-        }
-
-        public IWorldElement Get(IWorldServices worldServices)
-        {
-            return worldServices.GetObjectOrNull(new RefID(Id));
-        }
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public readonly struct WRefId<T> where T : class, IWorldElement
-    {
-        public readonly ulong Id;
-
-        public WRefId(RefID id)
+        public WasmRefID(RefID id)
         {
             Id = (ulong)id;
         }
@@ -40,14 +19,14 @@ namespace Derg.Wasm
             return worldServices.GetObjectOrNull(new RefID(Id)) as T;
         }
 
-        public static implicit operator WRefId(WRefId<T> p) => new WRefId(p.Id);
+        public static implicit operator RefID(WasmRefID<T> p) => new RefID(p.Id);
     }
 
     public static class WRefIdExtensions
     {
-        public static WRefId<T> GetWasmRef<T>(this T val) where T : class, IWorldElement
+        public static WasmRefID<T> GetWasmRef<T>(this T val) where T : class, IWorldElement
         {
-            return new WRefId<T>(val.ReferenceID);
+            return new WasmRefID<T>(val.ReferenceID);
         }
     }
 }

--- a/dergwasm_mod/Dergwasm/Wasm/RefId.cs
+++ b/dergwasm_mod/Dergwasm/Wasm/RefId.cs
@@ -1,0 +1,53 @@
+using System.Runtime.InteropServices;
+using Elements.Core;
+using FrooxEngine;
+
+namespace Derg.Wasm
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly struct WRefId
+    {
+        public readonly ulong Id;
+
+        public WRefId(RefID id)
+        {
+            Id = (ulong)id;
+        }
+
+        public WRefId<T> Reinterpret<T>() where T : class, IWorldElement
+        {
+            return new WRefId<T>(Id);
+        }
+
+        public IWorldElement Get(IWorldServices worldServices)
+        {
+            return worldServices.GetObjectOrNull(new RefID(Id));
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly struct WRefId<T> where T : class, IWorldElement
+    {
+        public readonly ulong Id;
+
+        public WRefId(RefID id)
+        {
+            Id = (ulong)id;
+        }
+
+        public T Get(IWorldServices worldServices)
+        {
+            return worldServices.GetObjectOrNull(new RefID(Id)) as T;
+        }
+
+        public static implicit operator WRefId(WRefId<T> p) => new WRefId(p.Id);
+    }
+
+    public static class WRefIdExtensions
+    {
+        public static WRefId<T> GetWasmRef<T>(this T val) where T : class, IWorldElement
+        {
+            return new WRefId<T>(val.ReferenceID);
+        }
+    }
+}

--- a/dergwasm_mod/DergwasmTests/ResoniteEnvValueGetSetTests.cs
+++ b/dergwasm_mod/DergwasmTests/ResoniteEnvValueGetSetTests.cs
@@ -55,7 +55,7 @@ namespace DergwasmTests
         [Fact]
         public void GetValueFailsOnNonexistentRefID()
         {
-            Assert.Equal(ResoniteError.InvalidRefId, env.value__get(frame, new WRefId<IValue<int>>(0xFFFFFFFFFFFFFFFFUL), new Ptr<int>(4)));
+            Assert.Equal(ResoniteError.InvalidRefId, env.value__get(frame, new WasmRefID<IValue<int>>(0xFFFFFFFFFFFFFFFFUL), new Ptr<int>(4)));
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace DergwasmTests
         {
             Assert.Equal(
                 ResoniteError.InvalidRefId,
-                env.value__get(frame, new WRefId<IValue<double>>(testComponent.IntField.ReferenceID), new Ptr<double>(4))
+                env.value__get(frame, new WasmRefID<IValue<double>>(testComponent.IntField.ReferenceID), new Ptr<double>(4))
             );
         }
 
@@ -118,7 +118,7 @@ namespace DergwasmTests
         public void SetValueFailsOnNonexistentRefID()
         {
             var dataPtr = new Ptr<int>(4);
-            Assert.Equal(ResoniteError.InvalidRefId, env.value__set(frame, new WRefId<IValue<int>>(0xFFFFFFFFFFFFFFFFUL), dataPtr));
+            Assert.Equal(ResoniteError.InvalidRefId, env.value__set(frame, new WasmRefID<IValue<int>>(0xFFFFFFFFFFFFFFFFUL), dataPtr));
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace DergwasmTests
             var dataPtr = new Ptr<double>(4);
             Assert.Equal(
                 ResoniteError.InvalidRefId,
-                env.value__set(frame, new WRefId<IValue<double>>(testComponent.IntField.ReferenceID), dataPtr)
+                env.value__set(frame, new WasmRefID<IValue<double>>(testComponent.IntField.ReferenceID), dataPtr)
             );
         }
 

--- a/dergwasm_mod/DergwasmTests/ResoniteEnvValueGetSetTests.cs
+++ b/dergwasm_mod/DergwasmTests/ResoniteEnvValueGetSetTests.cs
@@ -1,7 +1,5 @@
-﻿using System.Reflection;
-using Derg;
+﻿using Derg;
 using Derg.Wasm;
-using Elements.Core;
 using FrooxEngine;
 using Xunit;
 
@@ -31,40 +29,41 @@ namespace DergwasmTests
         [Fact]
         public void GetValueUnsetIntIsDefaultedTest()
         {
-            int dataPtr = 4;
+            var dataPtr = new Ptr<int>(4);
+
 
             Assert.Equal(
-                0,
-                env.value__get<int>(frame, (ulong)testComponent.IntField.ReferenceID, dataPtr)
+                ResoniteError.Success,
+                env.value__get(frame, testComponent.IntField.GetWasmRef<IValue<int>>(), dataPtr)
             );
-            Assert.Equal(0, HeapGet(new Ptr<int>(dataPtr)));
+            Assert.Equal(0, HeapGet(dataPtr));
         }
 
         [Fact]
         public void GetValueIntTest()
         {
             testComponent.IntField.Value = 1;
-            int dataPtr = 4;
+            var dataPtr = new Ptr<int>(4);
 
             Assert.Equal(
-                0,
-                env.value__get<int>(frame, (ulong)testComponent.IntField.ReferenceID, dataPtr)
+                ResoniteError.Success,
+                env.value__get(frame, testComponent.IntField.GetWasmRef<IValue<int>>(), dataPtr)
             );
-            Assert.Equal(1, HeapGet(new Ptr<int>(dataPtr)));
+            Assert.Equal(1, HeapGet(dataPtr));
         }
 
         [Fact]
         public void GetValueFailsOnNonexistentRefID()
         {
-            Assert.Equal(-1, env.value__get<int>(frame, 0xFFFFFFFFFFFFFFFFUL, 4));
+            Assert.Equal(ResoniteError.InvalidRefId, env.value__get(frame, new WRefId<IValue<int>>(0xFFFFFFFFFFFFFFFFUL), new Ptr<int>(4)));
         }
 
         [Fact]
         public void GetValueFailsOnWrongType()
         {
             Assert.Equal(
-                -1,
-                env.value__get<double>(frame, (ulong)testComponent.IntField.ReferenceID, 4)
+                ResoniteError.InvalidRefId,
+                env.value__get(frame, new WRefId<IValue<double>>(testComponent.IntField.ReferenceID), new Ptr<double>(4))
             );
         }
 
@@ -72,8 +71,8 @@ namespace DergwasmTests
         public void GetValueFailsOnNullDataPtr()
         {
             Assert.Equal(
-                -1,
-                env.value__get<int>(frame, (ulong)testComponent.IntField.ReferenceID, 0)
+                ResoniteError.NullArgument,
+                env.value__get(frame, testComponent.IntField.GetWasmRef<IValue<int>>(), Ptr<int>.Null)
             );
         }
 
@@ -81,36 +80,36 @@ namespace DergwasmTests
         public void GetValueFloatTest()
         {
             testComponent.FloatField.Value = 1;
-            int dataPtr = 4;
+            var dataPtr = new Ptr<float>(4);
 
             Assert.Equal(
-                0,
-                env.value__get<float>(frame, (ulong)testComponent.FloatField.ReferenceID, dataPtr)
+                ResoniteError.Success,
+                env.value__get(frame, testComponent.FloatField.GetWasmRef<IValue<float>>(), dataPtr)
             );
-            Assert.Equal(1, HeapGet(new Ptr<float>(dataPtr)));
+            Assert.Equal(1, HeapGet(dataPtr));
         }
 
         [Fact]
         public void GetValueDoubleTest()
         {
             testComponent.DoubleField.Value = 1;
-            int dataPtr = 4;
+            var dataPtr = new Ptr<double>(4);
 
             Assert.Equal(
-                0,
-                env.value__get<double>(frame, (ulong)testComponent.DoubleField.ReferenceID, dataPtr)
+                ResoniteError.Success,
+                env.value__get(frame, testComponent.DoubleField.GetWasmRef<IValue<double>>(), dataPtr)
             );
-            Assert.Equal(1, HeapGet(new Ptr<double>(dataPtr)));
+            Assert.Equal(1, HeapGet(dataPtr));
         }
 
         [Fact]
         public void SetValueTest()
         {
-            int dataPtr = 4;
-            HeapSet(new Ptr<int>(dataPtr), 12);
+            var dataPtr = new Ptr<int>(4);
+            HeapSet(dataPtr, 12);
             Assert.Equal(
-                0,
-                env.value__set<int>(frame, (ulong)testComponent.IntField.ReferenceID, dataPtr)
+                ResoniteError.Success,
+                env.value__set(frame, testComponent.IntField.GetWasmRef<IValue<int>>(), dataPtr)
             );
             Assert.Equal(12, testComponent.IntField.Value);
         }
@@ -118,15 +117,17 @@ namespace DergwasmTests
         [Fact]
         public void SetValueFailsOnNonexistentRefID()
         {
-            Assert.Equal(-1, env.value__set<int>(frame, 0xFFFFFFFFFFFFFFFFUL, 4));
+            var dataPtr = new Ptr<int>(4);
+            Assert.Equal(ResoniteError.InvalidRefId, env.value__set(frame, new WRefId<IValue<int>>(0xFFFFFFFFFFFFFFFFUL), dataPtr));
         }
 
         [Fact]
         public void SetValueFailsOnWrongType()
         {
+            var dataPtr = new Ptr<double>(4);
             Assert.Equal(
-                -1,
-                env.value__set<double>(frame, (ulong)testComponent.IntField.ReferenceID, 4)
+                ResoniteError.InvalidRefId,
+                env.value__set(frame, new WRefId<IValue<double>>(testComponent.IntField.ReferenceID), dataPtr)
             );
         }
 
@@ -134,8 +135,8 @@ namespace DergwasmTests
         public void SetValueFailsOnNullDataPtr()
         {
             Assert.Equal(
-                -1,
-                env.value__set<int>(frame, (ulong)testComponent.IntField.ReferenceID, 0)
+                ResoniteError.NullArgument,
+                env.value__set(frame, testComponent.IntField.GetWasmRef<IValue<int>>(), default)
             );
         }
     }


### PR DESCRIPTION
This needs benchmark verification to see if it's actually faster.

Custom handlers can be added to ValueAccessor, which now does getting and setting of values. It also may dynamically generate accessors for specific generic types (such as Ptr and WRefID).