### PR TITLE
Annotate strings and bools

### DIFF
--- a/dergwasm_mod/Benchmarks/Program.cs
+++ b/dergwasm_mod/Benchmarks/Program.cs
@@ -620,18 +620,17 @@ namespace DergwasmTests
         {
             emscriptenEnv.ResetMalloc();
             int sum = 0;
-            Buff<byte> namePtr = emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField");
-            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Ptr.Addr + 100);
+            NullTerminatedString namePtr = new NullTerminatedString(
+                emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField")
+            );
+            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Data.Addr + 100);
             Ptr<ulong> outRefIdPtr = new Ptr<ulong>(outTypePtr.Addr + sizeof(int));
             Ptr<int> outPtr = new Ptr<int>(outRefIdPtr.Addr + sizeof(ulong));
             WasmRefID<Component> refId = new WasmRefID<Component>(testComponent);
 
             for (int i = 0; i < N; i++)
             {
-                if (
-                    env.component__get_member(frame, refId, namePtr.Ptr, outTypePtr, outRefIdPtr)
-                    != 0
-                )
+                if (env.component__get_member(frame, refId, namePtr, outTypePtr, outRefIdPtr) != 0)
                 {
                     throw new Exception("component__get_member failed");
                 }

--- a/dergwasm_mod/Dergwasm/EmscriptenEnv.cs
+++ b/dergwasm_mod/Dergwasm/EmscriptenEnv.cs
@@ -112,6 +112,10 @@ namespace Derg
             return GetUTF8StringFromMem(ptr.Addr);
         }
 
+        // Gets the NUL-terminated UTF8-encoded string at the given pointer in the heap.
+        public string GetUTF8StringFromMem(NullTerminatedString s) =>
+            GetUTF8StringFromMem(s.Data.Addr);
+
         // Gets the UTF8-encoded string of the given byte length at the given pointer
         // in the heap. Because the length is given, the string does not have to be
         // NUL-terminated.

--- a/dergwasm_mod/Dergwasm/ResoniteEnv.cs
+++ b/dergwasm_mod/Dergwasm/ResoniteEnv.cs
@@ -196,19 +196,19 @@ namespace Derg
         }
 
         [ModFn("slot__get_name")]
-        public Ptr<byte> slot__get_name(Frame frame, WasmRefID<ISlot> slot)
+        public NullTerminatedString slot__get_name(Frame frame, WasmRefID<ISlot> slot)
         {
             string name = worldServices.GetObjectOrNull(slot)?.Name ?? "";
-            return emscriptenEnv.AllocateUTF8StringInMem(frame, name).ToPointer();
+            return new NullTerminatedString(emscriptenEnv.AllocateUTF8StringInMem(frame, name));
         }
 
         [ModFn("slot__set_name")]
-        public void slot__set_name(Frame frame, WasmRefID<ISlot> slot, Ptr<byte> ptr)
+        public void slot__set_name(Frame frame, WasmRefID<ISlot> slot, NullTerminatedString name)
         {
             ISlot islot = worldServices.GetObjectOrNull(slot);
             if (islot == null)
                 return;
-            islot.Name = emscriptenEnv.GetUTF8StringFromMem(ptr);
+            islot.Name = emscriptenEnv.GetUTF8StringFromMem(name);
         }
 
         [ModFn("slot__get_num_children")]
@@ -232,7 +232,7 @@ namespace Derg
         public WasmRefID<ISlot> slot__find_child_by_name(
             Frame frame,
             WasmRefID<ISlot> slot,
-            Ptr<byte> namePtr,
+            NullTerminatedString namePtr,
             int match_substring,
             int ignore_case,
             int max_depth
@@ -249,7 +249,7 @@ namespace Derg
         public WasmRefID<ISlot> slot__find_child_by_tag(
             Frame frame,
             WasmRefID<ISlot> slot,
-            Ptr<byte> tagPtr,
+            NullTerminatedString tagPtr,
             int max_depth
         )
         {
@@ -264,7 +264,7 @@ namespace Derg
         public WasmRefID<Component> slot__get_component(
             Frame frame,
             WasmRefID<ISlot> slot,
-            Ptr<byte> typeNamePtr
+            NullTerminatedString typeNamePtr
         )
         {
             string typeName = emscriptenEnv.GetUTF8StringFromMem(typeNamePtr);
@@ -275,11 +275,14 @@ namespace Derg
         }
 
         [ModFn("component__get_type_name")]
-        public Ptr<byte> component__get_type_name(Frame frame, WasmRefID<Component> component_id)
+        public NullTerminatedString component__get_type_name(
+            Frame frame,
+            WasmRefID<Component> component_id
+        )
         {
             string typeName =
                 worldServices.GetObjectOrNull(component_id)?.GetType().GetNiceName() ?? "";
-            return emscriptenEnv.AllocateUTF8StringInMem(frame, typeName).Ptr;
+            return new NullTerminatedString(emscriptenEnv.AllocateUTF8StringInMem(frame, typeName));
         }
 
         public enum ResoniteType : int
@@ -303,7 +306,7 @@ namespace Derg
         public int component__get_member(
             Frame frame,
             WasmRefID<Component> componentRefId,
-            Ptr<byte> namePtr,
+            NullTerminatedString namePtr,
             Ptr<int> outTypePtr,
             Ptr<ulong> outRefIdPtr
         )
@@ -311,7 +314,7 @@ namespace Derg
             Component component = worldServices.GetObjectOrNull(componentRefId);
             if (
                 component == null
-                || namePtr.Addr == 0
+                || namePtr.Data.Addr == 0
                 || outTypePtr.Addr == 0
                 || outRefIdPtr.Addr == 0
             )

--- a/dergwasm_mod/Dergwasm/ResoniteEnv.cs
+++ b/dergwasm_mod/Dergwasm/ResoniteEnv.cs
@@ -186,13 +186,11 @@ namespace Derg
         public WasmRefID<ISlot> slot__get_object_root(
             Frame frame,
             WasmRefID<ISlot> slot,
-            int only_explicit
+            bool only_explicit
         )
         {
-            return worldServices
-                    .GetObjectOrNull(slot)
-                    ?.GetObjectRoot(only_explicit != 0)
-                    ?.GetWasmRef() ?? default;
+            return worldServices.GetObjectOrNull(slot)?.GetObjectRoot(only_explicit)?.GetWasmRef()
+                ?? default;
         }
 
         [ModFn("slot__get_name")]
@@ -233,15 +231,15 @@ namespace Derg
             Frame frame,
             WasmRefID<ISlot> slot,
             NullTerminatedString namePtr,
-            int match_substring,
-            int ignore_case,
+            bool match_substring,
+            bool ignore_case,
             int max_depth
         )
         {
             string name = emscriptenEnv.GetUTF8StringFromMem(namePtr);
             return worldServices
                     .GetObjectOrNull(slot)
-                    ?.FindChild(name, match_substring != 0, ignore_case != 0, max_depth)
+                    ?.FindChild(name, match_substring, ignore_case, max_depth)
                     ?.GetWasmRef() ?? default;
         }
 

--- a/dergwasm_mod/Dergwasm/Wasm/String.cs
+++ b/dergwasm_mod/Dergwasm/Wasm/String.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Derg.Wasm
+{
+    // Represents a pointer to bytes to be interpreted as a NUL-terminated UTF8-encoded
+    // string.
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly struct NullTerminatedString
+    {
+        public readonly Ptr<byte> Data;
+
+        public NullTerminatedString(Ptr<byte> data)
+        {
+            Data = data;
+        }
+
+        public NullTerminatedString(Buff<byte> buffer)
+        {
+            Data = buffer.Ptr;
+        }
+
+        public NullTerminatedString(int addr)
+        {
+            Data = new Ptr<byte>(addr);
+        }
+    }
+}

--- a/dergwasm_mod/DergwasmTests/ResoniteEnvComponentTests.cs
+++ b/dergwasm_mod/DergwasmTests/ResoniteEnvComponentTests.cs
@@ -30,8 +30,10 @@ namespace DergwasmTests
         [Fact]
         public void GetMemberTest()
         {
-            Buff<byte> namePtr = emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField");
-            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Ptr.Addr + 100);
+            NullTerminatedString namePtr = new NullTerminatedString(
+                emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField")
+            );
+            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Data.Addr + 100);
             Ptr<ulong> outRefIdPtr = new Ptr<ulong>(outTypePtr.Addr + sizeof(int));
 
             Assert.Equal(
@@ -39,7 +41,7 @@ namespace DergwasmTests
                 env.component__get_member(
                     frame,
                     new WasmRefID<Component>(testComponent),
-                    namePtr.Ptr,
+                    namePtr,
                     outTypePtr,
                     outRefIdPtr
                 )
@@ -54,8 +56,10 @@ namespace DergwasmTests
         [Fact]
         public void GetMemberFailsOnNonexistentRefID()
         {
-            Buff<byte> namePtr = emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField");
-            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Ptr.Addr + 100);
+            NullTerminatedString namePtr = new NullTerminatedString(
+                emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField")
+            );
+            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Data.Addr + 100);
             Ptr<ulong> outRefIdPtr = new Ptr<ulong>(outTypePtr.Addr + sizeof(int));
 
             Assert.Equal(
@@ -63,7 +67,7 @@ namespace DergwasmTests
                 env.component__get_member(
                     frame,
                     new WasmRefID<Component>(0xFFFFFFFFFFFFFFFFUL),
-                    namePtr.Ptr,
+                    namePtr,
                     outTypePtr,
                     outRefIdPtr
                 )
@@ -73,8 +77,10 @@ namespace DergwasmTests
         [Fact]
         public void GetMemberFailsOnNoncomponentRefID()
         {
-            Buff<byte> namePtr = emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField");
-            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Ptr.Addr + 100);
+            NullTerminatedString namePtr = new NullTerminatedString(
+                emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField")
+            );
+            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Data.Addr + 100);
             Ptr<ulong> outRefIdPtr = new Ptr<ulong>(outTypePtr.Addr + sizeof(int));
 
             Assert.Equal(
@@ -82,7 +88,7 @@ namespace DergwasmTests
                 env.component__get_member(
                     frame,
                     new WasmRefID<Component>(testComponent.IntField.ReferenceID),
-                    namePtr.Ptr,
+                    namePtr,
                     outTypePtr,
                     outRefIdPtr
                 )
@@ -92,8 +98,8 @@ namespace DergwasmTests
         [Fact]
         public void GetMemberFailsOnNullNamePtr()
         {
-            Buff<byte> namePtr = new Buff<byte>(0, 0);
-            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Ptr.Addr + 100);
+            NullTerminatedString namePtr = new NullTerminatedString(0);
+            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Data.Addr + 100);
             Ptr<ulong> outRefIdPtr = new Ptr<ulong>(outTypePtr.Addr + sizeof(int));
 
             Assert.Equal(
@@ -101,7 +107,7 @@ namespace DergwasmTests
                 env.component__get_member(
                     frame,
                     new WasmRefID<Component>(testComponent),
-                    namePtr.Ptr,
+                    namePtr,
                     outTypePtr,
                     outRefIdPtr
                 )
@@ -111,7 +117,9 @@ namespace DergwasmTests
         [Fact]
         public void GetMemberFailsOnNullTypePtr()
         {
-            Buff<byte> namePtr = emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField");
+            NullTerminatedString namePtr = new NullTerminatedString(
+                emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField")
+            );
             Ptr<int> outTypePtr = new Ptr<int>(0);
             Ptr<ulong> outRefIdPtr = new Ptr<ulong>(outTypePtr.Addr + sizeof(int));
 
@@ -120,7 +128,7 @@ namespace DergwasmTests
                 env.component__get_member(
                     frame,
                     new WasmRefID<Component>(testComponent),
-                    namePtr.Ptr,
+                    namePtr,
                     outTypePtr,
                     outRefIdPtr
                 )
@@ -130,8 +138,10 @@ namespace DergwasmTests
         [Fact]
         public void GetMemberFailsOnNullRefIdPtr()
         {
-            Buff<byte> namePtr = emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField");
-            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Ptr.Addr + 100);
+            NullTerminatedString namePtr = new NullTerminatedString(
+                emscriptenEnv.AllocateUTF8StringInMem(frame, "IntField")
+            );
+            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Data.Addr + 100);
             Ptr<ulong> outRefIdPtr = new Ptr<ulong>(0);
 
             Assert.Equal(
@@ -139,7 +149,7 @@ namespace DergwasmTests
                 env.component__get_member(
                     frame,
                     new WasmRefID<Component>(testComponent),
-                    namePtr.Ptr,
+                    namePtr,
                     outTypePtr,
                     outRefIdPtr
                 )
@@ -149,8 +159,10 @@ namespace DergwasmTests
         [Fact]
         public void GetMemberFailsOnNonexistentField()
         {
-            Buff<byte> namePtr = emscriptenEnv.AllocateUTF8StringInMem(frame, "CatFace");
-            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Ptr.Addr + 100);
+            NullTerminatedString namePtr = new NullTerminatedString(
+                emscriptenEnv.AllocateUTF8StringInMem(frame, "CatFace")
+            );
+            Ptr<int> outTypePtr = new Ptr<int>(namePtr.Data.Addr + 100);
             Ptr<ulong> outRefIdPtr = new Ptr<ulong>(outTypePtr.Addr + sizeof(int));
 
             Assert.Equal(
@@ -158,7 +170,7 @@ namespace DergwasmTests
                 env.component__get_member(
                     frame,
                     new WasmRefID<Component>(testComponent.IntField.ReferenceID),
-                    namePtr.Ptr,
+                    namePtr,
                     outTypePtr,
                     outRefIdPtr
                 )

--- a/dergwasm_mod/DergwasmTests/ResoniteEnvSlotTests.cs
+++ b/dergwasm_mod/DergwasmTests/ResoniteEnvSlotTests.cs
@@ -60,15 +60,20 @@ namespace DergwasmTests
         [Fact]
         public void GetNameTest()
         {
-            Ptr<byte> dataPtr = env.slot__get_name(frame, new WasmRefID<ISlot>(testSlot));
+            NullTerminatedString dataPtr = env.slot__get_name(
+                frame,
+                new WasmRefID<ISlot>(testSlot)
+            );
             Assert.Equal(testSlot.Name, emscriptenEnv.GetUTF8StringFromMem(dataPtr));
         }
 
         [Fact]
         public void SetNameTest()
         {
-            Buff<byte> buff = emscriptenEnv.AllocateUTF8StringInMem(frame, "new name");
-            env.slot__set_name(frame, new WasmRefID<ISlot>(testSlot), buff.Ptr);
+            NullTerminatedString buff = new NullTerminatedString(
+                emscriptenEnv.AllocateUTF8StringInMem(frame, "new name")
+            );
+            env.slot__set_name(frame, new WasmRefID<ISlot>(testSlot), buff);
             Assert.Equal("new name", testSlot.Name);
         }
     }


### PR DESCRIPTION
This allows us to specify that an int (or what was a Ptr<byte>) is a null-terminated string in APIs.

Also makes bool args bool in the API.