### PR TITLE
Swapped from frame push and pop to marshallers.

### DIFF
--- a/dergwasm_mod/Benchmarks/Program.cs
+++ b/dergwasm_mod/Benchmarks/Program.cs
@@ -197,7 +197,7 @@ namespace DergwasmTests
             for (int i = 0; i < N; i++)
             {
                 frame.Push(new Value { s32 = 1 });
-                frame.Pop(out y);
+                y = frame.Pop<int>();
                 x += y;
             }
             return x;

--- a/dergwasm_mod/Dergwasm/Modules/ApiData.cs
+++ b/dergwasm_mod/Dergwasm/Modules/ApiData.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 using Derg.Runtime;
 
@@ -19,17 +20,15 @@ namespace Derg.Modules
         public List<Parameter> Returns { get; }
 
         [JsonIgnore]
-        public List<ValueType> ParameterValueTypes { get; }
+        public IEnumerable<ValueType> ParameterValueTypes => Parameters.Select(p => p.Type);
 
         [JsonIgnore]
-        public List<ValueType> ReturnValueTypes { get; }
+        public IEnumerable<ValueType> ReturnValueTypes => Returns.Select(p => p.Type);
 
         public ApiFunc()
         {
             Parameters = new List<Parameter>();
             Returns = new List<Parameter>();
-            ParameterValueTypes = new List<ValueType>();
-            ReturnValueTypes = new List<ValueType>();
         }
     }
 }

--- a/dergwasm_mod/Dergwasm/Modules/ApiData.cs
+++ b/dergwasm_mod/Dergwasm/Modules/ApiData.cs
@@ -16,19 +16,13 @@ namespace Derg.Modules
     {
         public string Module { get; set; }
         public string Name { get; set; }
-        public List<Parameter> Parameters { get; }
-        public List<Parameter> Returns { get; }
+        public List<Parameter> Parameters { get; } = new List<Parameter>();
+        public List<Parameter> Returns { get; } = new List<Parameter>();
 
         [JsonIgnore]
-        public IEnumerable<ValueType> ParameterValueTypes => Parameters.Select(p => p.Type);
+        public IEnumerable<ValueType> ParameterValueTypes => Parameters.SelectMany(p => p.Types);
 
         [JsonIgnore]
-        public IEnumerable<ValueType> ReturnValueTypes => Returns.Select(p => p.Type);
-
-        public ApiFunc()
-        {
-            Parameters = new List<Parameter>();
-            Returns = new List<Parameter>();
-        }
+        public IEnumerable<ValueType> ReturnValueTypes => Returns.SelectMany(p => p.Types);
     }
 }

--- a/dergwasm_mod/Dergwasm/Modules/IWasmMarshaller.cs
+++ b/dergwasm_mod/Dergwasm/Modules/IWasmMarshaller.cs
@@ -1,0 +1,32 @@
+using Derg.Runtime;
+using Dergwasm.Runtime;
+using Elements.Core;
+using System;
+using System.Collections.Generic;
+
+namespace Derg.Modules {
+    public interface IWasmMarshaller<T> {
+        // Get the type information for a parameter, Name will be filled out later.
+        void AddParams(string name, List<Parameter> parameters);
+        void To(Frame frame, Machine machine, T value);
+        T From(Frame frame, Machine machine);
+    }
+
+    public struct DirectMarshaller<T> : IWasmMarshaller<T>
+    {
+
+        public void AddParams(string name, List<Parameter> parameters)
+        {
+            parameters.Add(new Parameter
+            {
+                Name = name,
+                Type = ModuleReflector.ValueTypeFor(typeof(T)),
+                CSType = typeof(T).GetNiceName()
+            });
+        }
+
+        public T From(Frame frame, Machine machine) => frame.Pop().As<T>();
+
+        public void To(Frame frame, Machine machine, T value) => frame.Push(Value.From(value));
+    }
+}

--- a/dergwasm_mod/Dergwasm/Modules/IWasmMarshaller.cs
+++ b/dergwasm_mod/Dergwasm/Modules/IWasmMarshaller.cs
@@ -1,7 +1,6 @@
 using Derg.Runtime;
 using Dergwasm.Runtime;
 using Elements.Core;
-using System;
 using System.Collections.Generic;
 
 namespace Derg.Modules {
@@ -14,13 +13,12 @@ namespace Derg.Modules {
 
     public struct DirectMarshaller<T> : IWasmMarshaller<T>
     {
-
         public void AddParams(string name, List<Parameter> parameters)
         {
             parameters.Add(new Parameter
             {
                 Name = name,
-                Type = ModuleReflector.ValueTypeFor(typeof(T)),
+                Types = ModuleReflector.ValueTypesFor(typeof(T)),
                 CSType = typeof(T).GetNiceName()
             });
         }

--- a/dergwasm_mod/Dergwasm/Modules/ModuleReflector.cs
+++ b/dergwasm_mod/Dergwasm/Modules/ModuleReflector.cs
@@ -28,14 +28,14 @@ namespace Derg.Modules
             Func<object, (ApiFunc, HostFunc)[]>
         > _reflectedFuncs = new ConcurrentDictionary<Type, Func<object, (ApiFunc, HostFunc)[]>>();
 
-        public static Runtime.ValueType ValueTypeFor(Type type)
+        public static Runtime.ValueType[] ValueTypesFor(Type type)
         {
-            var valueType = (Runtime.ValueType)
+            var valueTypes = (Runtime.ValueType[])
                 typeof(Value)
                     .GetMethod(nameof(Value.ValueType))
                     .MakeGenericMethod(type)
                     .Invoke(null, null);
-            return valueType;
+            return valueTypes;
         }
 
         public static Type MarshallerFor(ParameterInfo info)
@@ -50,7 +50,7 @@ namespace Derg.Modules
             if (marshaller.IsGenericTypeDefinition)
             {
                 // If the marshaller is a generic type, assume the marshaller has the same type arguments.
-                marshaller = marshaller.MakeGenericType(info.ParameterType.GetGenericTypeDefinition());
+                marshaller = marshaller.MakeGenericType(info.ParameterType.GenericTypeArguments);
             }
             return marshaller;
         }

--- a/dergwasm_mod/Dergwasm/Modules/ModuleReflector.cs
+++ b/dergwasm_mod/Dergwasm/Modules/ModuleReflector.cs
@@ -10,12 +10,50 @@ using System.Reflection;
 
 namespace Derg.Modules
 {
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.Struct)]
+    public class MarshalWithAttribute : Attribute
+    {
+        public Type Marshaller { get; }
+
+        public MarshalWithAttribute(Type marshaller)
+        {
+            Marshaller = marshaller;
+        }
+    }
+
     public static class ModuleReflector
     {
         private static readonly ConcurrentDictionary<
             Type,
             Func<object, (ApiFunc, HostFunc)[]>
         > _reflectedFuncs = new ConcurrentDictionary<Type, Func<object, (ApiFunc, HostFunc)[]>>();
+
+        public static Runtime.ValueType ValueTypeFor(Type type)
+        {
+            var valueType = (Runtime.ValueType)
+                typeof(Value)
+                    .GetMethod(nameof(Value.ValueType))
+                    .MakeGenericMethod(type)
+                    .Invoke(null, null);
+            return valueType;
+        }
+
+        public static Type MarshallerFor(ParameterInfo info)
+        {
+            var marshaller = info.GetCustomAttribute<MarshalWithAttribute>()?.Marshaller ??
+                info.ParameterType.GetCustomAttribute<MarshalWithAttribute>()?.Marshaller ??
+                typeof(DirectMarshaller<>).MakeGenericType(info.ParameterType);
+            if (marshaller.IsByRef)
+            {
+                throw new InvalidOperationException("Marshallers must be structs.");
+            }
+            if (marshaller.IsGenericTypeDefinition)
+            {
+                // If the marshaller is a generic type, assume the marshaller has the same type arguments.
+                marshaller = marshaller.MakeGenericType(info.ParameterType.GetGenericTypeDefinition());
+            }
+            return marshaller;
+        }
 
         public static (ApiFunc, HostFunc)[] ReflectHostFuncs<T>(T ctx)
         {
@@ -92,16 +130,6 @@ namespace Derg.Modules
             return lambda.Compile();
         }
 
-        private static Runtime.ValueType ValueTypeFor(Type type)
-        {
-            var valueType = (Runtime.ValueType)
-                typeof(Value)
-                    .GetMethod(nameof(Value.ValueType))
-                    .MakeGenericMethod(type)
-                    .Invoke(null, null);
-            return valueType;
-        }
-
         private static Expression /*(ApiFunc, HostFunc)*/
         ReflectHostFunc(string name, string module, MethodInfo method, ParameterExpression context)
         {
@@ -157,7 +185,7 @@ namespace Derg.Modules
             var machine = Expression.Parameter(typeof(Machine), "machine");
             var frame = Expression.Parameter(typeof(Frame), "frame");
 
-            var poppers = new List<Expression>();
+            var body = new List<Expression>();
             var callParams = new List<ParameterExpression>();
             var outVars = new List<ParameterExpression>();
             foreach (var param in method.GetParameters())
@@ -182,35 +210,23 @@ namespace Derg.Modules
                 outVars.Add(poppedValue);
 
                 // Call the appropriate pop method for the type.
-                string refTypeName = param.ParameterType.MakeByRefType().Name;
-                MethodInfo popper = typeof(Frame)
-                    .GetMethods()
-                    .Where(m => m.Name == "Pop")
-                    .Where(m => m.GetParameters().Length == 1)
-                    .Where(m => m.GetParameters()[0].IsOut)
-                    .Where(m => m.GetParameters()[0].ParameterType.Name == refTypeName)
-                    .First();
-                if (param.ParameterType.IsGenericType)
-                {
-                    popper = popper.MakeGenericMethod(param.ParameterType.GetGenericArguments());
-                }
-                MethodCallExpression popperCaller = Expression.Call(frame, popper, poppedValue);
-                poppers.Add(popperCaller);
+                Type marshaller = MarshallerFor(param);
+                MethodInfo popper = marshaller.GetMethod(nameof(IWasmMarshaller<int>.From));
+                Expression popperCaller = Expression.Assign(poppedValue, Expression.Call(
+                    Expression.Default(marshaller),
+                    popper,
+                    frame,
+                    machine));
+                body.Add(popperCaller);
 
-                funcData.Parameters.Add(
-                    new Parameter
-                    {
-                        Name = param.Name,
-                        Type = ValueTypeFor(param.ParameterType),
-                        CSType = param.ParameterType.GetNiceName()
-                    }
-                );
-                funcData.ParameterValueTypes.Add(ValueTypeFor(param.ParameterType));
+                marshaller.GetMethod(nameof(IWasmMarshaller<int>.AddParams))
+                    .Invoke(marshaller.GetDefault(),
+                    new object[] { param.Name, funcData.Parameters });
             }
 
             // The poppers need to be reversed. The first value pushed is the first call arg,
             // which means that the first value popped is the *last* call arg.
-            poppers.Reverse();
+            body.Reverse();
 
             // The actual inner call to the host func.
             var result = Expression.Call(method.IsStatic ? null : context, method, callParams);
@@ -220,29 +236,27 @@ namespace Derg.Modules
             {
                 returnsCount++;
                 // Process return value.
-                result = Expression.Call(
+                ParameterInfo param = method.ReturnParameter;
+                Type marshaller = MarshallerFor(param);
+                MethodInfo pusher = marshaller.GetMethod(nameof(IWasmMarshaller<int>.To));
+                MethodCallExpression pusherCaller = Expression.Call(
+                    Expression.Default(marshaller),
+                    pusher,
                     frame,
-                    typeof(Frame)
-                        .GetMethods()
-                        .First(m => m.Name == nameof(Frame.Push) && m.IsGenericMethod)
-                        .MakeGenericMethod(method.ReturnType),
-                    result
-                );
+                    machine,
+                    result);
 
-                funcData.Returns.Add(
-                    new Parameter
-                    {
-                        Type = ValueTypeFor(method.ReturnType),
-                        CSType = method.ReturnType.GetNiceName()
-                    }
-                );
-                funcData.ReturnValueTypes.Add(ValueTypeFor(method.ReturnType));
+                result = pusherCaller;
+
+                marshaller.GetMethod(nameof(IWasmMarshaller<int>.AddParams))
+                    .Invoke(marshaller.GetDefault(),
+                    new object[] { null, funcData.Returns });
 
                 // TODO: Add the ability to process value tuple based return values.
             }
-            poppers.Add(result);
+            body.Add(result);
 
-            BlockExpression block = Expression.Block(outVars.ToArray(), poppers);
+            BlockExpression block = Expression.Block(outVars.ToArray(), body);
 
             // This is the invoked callsite. To improve per-call performance, optimize the expression
             // structure going into this compilation.

--- a/dergwasm_mod/Dergwasm/Runtime/Frame.cs
+++ b/dergwasm_mod/Dergwasm/Runtime/Frame.cs
@@ -102,93 +102,9 @@ namespace Derg.Runtime
 
         public T Pop<T>() => Pop().As<T>();
 
-        public void Pop(out bool val) => val = (Pop().s32 != 0 ? true : false);
-
-        public void Pop(out int val) => val = Pop().s32;
-
-        public void Pop(out uint val) => val = Pop().u32;
-
-        public void Pop(out long val) => val = Pop().s64;
-
-        public void Pop(out ulong val) => val = Pop().u64;
-
-        public void Pop(out float val) => val = Pop().f32;
-
-        public void Pop(out double val) => val = Pop().f64;
-
-        public void Pop(out ResoniteError val) => val = (ResoniteError)Pop().s32;
-
-        public void Pop(out ResoniteEnv.ResoniteType val) =>
-            val = (ResoniteEnv.ResoniteType)Pop().s32;
-
-        public void Pop<T>(out WasmRefID<T> refId)
-            where T : class, IWorldElement => refId = new WasmRefID<T>(Pop().u64);
-
-        public void Pop<T>(out Ptr<T> ptr)
-            where T : struct => ptr = new Ptr<T>(Pop().s32);
-
-        public void Pop(out NullTerminatedString ptr) => ptr = new NullTerminatedString(Pop().s32);
-
-        public void Pop<T>(out Output<T> ptr)
-            where T : struct => ptr = new Output<T>(Pop().s32);
-
-        public void Pop<T>(out WasmArray<T> ptr)
-            where T : struct => ptr = new WasmArray<T>(Pop().s32);
-
-        public void Pop<T>(out Buff<T> buff)
-            where T : struct
-        {
-            // The first value pushed is the first call arg.
-            // The first value popped is the last call arg.
-            // A buff argument is (data, len), so in pop order, it's (len, data).
-            int len = Pop().s32;
-            int data = Pop().s32;
-            buff = new Buff<T>(len, data);
-        }
-
         public void Push<T>(in T value) => value_stack.Push(Value.From(value));
 
         public void Push(Value val) => value_stack.Push(val);
-
-        public void Push(bool val) => Push(new Value { u32 = val ? 1u : 0u });
-
-        public void Push(int val) => Push(new Value { s32 = val });
-
-        public void Push(uint val) => Push(new Value { u32 = val });
-
-        public void Push(long val) => Push(new Value { s64 = val });
-
-        public void Push(ulong val) => Push(new Value { u64 = val });
-
-        public void Push(float val) => Push(new Value { f32 = val });
-
-        public void Push(double val) => Push(new Value { f64 = val });
-
-        public void Push(ResoniteError val) => Push((int)val);
-
-        public void Push(ResoniteEnv.ResoniteType val) => Push((int)val);
-
-        public void Push<T>(WasmRefID<T> val)
-            where T : class, IWorldElement => Push(val.Id);
-
-        public void Push<T>(Ptr<T> val)
-            where T : struct => Push(val.Addr);
-
-        public void Push(NullTerminatedString val) => Push(val.Data.Addr);
-
-        public void Push<T>(Output<T> val)
-            where T : struct => Push(val.Ptr.Addr);
-
-        public void Push<T>(WasmArray<T> val)
-            where T : struct => Push(val.Data.Addr);
-
-        public void Push<T>(Buff<T> val)
-            where T : struct
-        {
-            // A buff argument is (data, len).
-            Push(val.Ptr.Addr);
-            Push(val.Length);
-        }
 
         public int StackLevel() => value_stack.Count;
 

--- a/dergwasm_mod/Dergwasm/Wasm/Buff.cs
+++ b/dergwasm_mod/Dergwasm/Wasm/Buff.cs
@@ -9,24 +9,23 @@ namespace Derg.Wasm
 {
     public struct BuffMarshaller : IWasmMarshaller<Buff>
     {
-        public void AddParams(string name, List<Parameter> parameters) {
+        public void AddParams(string name, List<Parameter> parameters)
+        {
             parameters.Add(new Parameter
             {
-                Name = $"{name}_ptr",
-                Type = ModuleReflector.ValueTypeFor(typeof(int)),
-                CSType = typeof(int).GetNiceName()
-            }); parameters.Add(new Parameter
-            {
-                Name = $"{name}_len",
-                Type = ModuleReflector.ValueTypeFor(typeof(int)),
-                CSType = typeof(int).GetNiceName()
+                Name = name,
+                Types = new[] {
+                    ValueType.I32,
+                    ValueType.I32
+                },
+                CSType = typeof(Buff).GetNiceName()
             });
         }
 
         public Buff From(Frame frame, Machine machine)
         {
-            var addr = frame.Pop().s32;
             var size = frame.Pop().s32;
+            var addr = frame.Pop().s32;
             return new Buff(addr, size);
         }
 
@@ -79,21 +78,19 @@ namespace Derg.Wasm
         {
             parameters.Add(new Parameter
             {
-                Name = $"{name}_ptr",
-                Type = ModuleReflector.ValueTypeFor(typeof(int)),
-                CSType = typeof(int).GetNiceName()
-            }); parameters.Add(new Parameter
-            {
-                Name = $"{name}_len",
-                Type = ModuleReflector.ValueTypeFor(typeof(int)),
-                CSType = typeof(int).GetNiceName()
+                Name = name,
+                Types = new[] {
+                    ValueType.I32,
+                    ValueType.I32
+                },
+                CSType = typeof(Buff<T>).GetNiceName()
             });
         }
 
         public Buff<T> From(Frame frame, Machine machine)
         {
-            var addr = frame.Pop().s32;
             var size = frame.Pop().s32;
+            var addr = frame.Pop().s32;
             return new Buff<T>(addr, size);
         }
 

--- a/dergwasm_mod/Dergwasm/Wasm/Ptr.cs
+++ b/dergwasm_mod/Dergwasm/Wasm/Ptr.cs
@@ -1,6 +1,5 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using static HarmonyLib.Code;
 
 namespace Derg.Wasm
 {

--- a/dergwasm_mod/DergwasmTests/FrameTests.cs
+++ b/dergwasm_mod/DergwasmTests/FrameTests.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Derg.Wasm;
 using Derg.Runtime;
-using Elements.Core;
 using FrooxEngine;
 using Xunit;
-using Derg;
 using System.Reflection;
 using System.Linq.Expressions;
 

--- a/dergwasm_mod/DergwasmTests/FrameTests.cs
+++ b/dergwasm_mod/DergwasmTests/FrameTests.cs
@@ -12,7 +12,7 @@ namespace DergwasmTests
 {
     public class FrameTests
     {
-        [Fact]
+        [Fact(Skip = "Test not relevant with marshallers.")]
         public void TestFrame()
         {
             Frame f = new Frame(null, null, null);

--- a/dergwasm_mod/DergwasmTests/Modules/ReflectedModuleTests.cs
+++ b/dergwasm_mod/DergwasmTests/Modules/ReflectedModuleTests.cs
@@ -193,7 +193,7 @@ namespace Derg.Modules
         public void BuffArgPassedCorrectly()
         {
             var method = module.GetHostFunc("buff_arg");
-            frame.Push(new Buff<byte>(new Ptr<byte>(5), 10));
+            new BuffMarshaller<byte>().To(frame, machine, new Buff<byte>(new Ptr<byte>(5), 10));
             frame.InvokeFunc(machine, method);
             Assert.Equal(10, module.ReceivedBuffArg.Length);
             Assert.Equal(5, module.ReceivedBuffArg.Ptr.Addr);


### PR DESCRIPTION
These would allow callsites to customize how values are passed without altering the value itself.

This comes from LibraryImport, where value structs are created and used as conversion methods. Marshallers must be structs, but this enables any kind of type to be marshalled to and from the stack (including multiple return parameters).